### PR TITLE
Update to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,6 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
   post: 'cleanup.js'


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/