### PR TITLE
Resolves s4u/maven-settings-action#348, plugin repositories support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ steps:
 result will be:
 
 ```xml
-<server>
+<servers><server>
     <id>serverId</id>
     <configuration>
       <item1>value1</item1>
@@ -174,6 +174,14 @@ steps:
 - uses: s4u/maven-settings-action@v3.0.0
   with:
     repositories: '[{"id":"repoId","name":"repoName","url":"url","snapshots":{"enabled":true}}]'
+```
+
+## ```settings.xml``` with custom plugin repositories
+```yml
+steps:
+- uses: s4u/maven-settings-action@v3.0.0
+  with:
+    pluginRepositories: '[{"id":"repoId","name":"repoName","url":"url","snapshots":{"enabled":true}}]'
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ inputs:
   repositories:
     description: 'list of custom repositories as json array, e.g: [{"id":"repoId","name":"repoName","url":"url","snapshots":{"enabled":true}}]'
     required: false
+  pluginRepositories:
+    description: 'list of custom plugin repositories as json array, e.g: [{"id":"repoId","name":"repoName","url":"url","snapshots":{"enabled":true}}]'
+    required: false
 
 runs:
   using: 'node20'

--- a/cleanup.test.js
+++ b/cleanup.test.js
@@ -49,7 +49,7 @@ afterAll(() => {
     }
 
     try {
-        fs.rmdirSync(testHomePath);
+        fs.rmSync(testHomePath, { recursive: true });
     } catch (error) {
     }
 });

--- a/index.test.js
+++ b/index.test.js
@@ -55,7 +55,7 @@ afterAll(() => {
     }
 
     try {
-        fs.rmdirSync(testHomePath);
+        fs.rmSync(testHomePath, { recursive: true });
     } catch (error) {
     }
 });
@@ -75,6 +75,7 @@ test('run with all feature', () => {
     process.env['INPUT_SONATYPESNAPSHOTS'] = true;
     process.env['INPUT_ORACLEREPO'] = true;
     process.env['INPUT_REPOSITORIES'] = '[{"id":"repoId","name":"repoName","url":"url","snapshots":{"enabled":true}}]'
+    process.env['INPUT_PLUGINREPOSITORIES'] = '[{"id":"repoId","name":"repoName","url":"url","snapshots":{"enabled":true}}]'
 
     cp.spawnSync('node', [ `${indexPath}` ], { env: process.env, stdio: 'inherit' });
     const settingsStatus = fs.lstatSync(settingsPath);
@@ -213,7 +214,12 @@ test('run with all feature', () => {
      <url>url</url>
      <snapshots><enabled>true</enabled></snapshots>
  </repository></repositories>
-    <pluginRepositories/>
+    <pluginRepositories> <pluginRepository>
+     <id>repoId</id>
+     <name>repoName</name>
+     <url>url</url>
+     <snapshots><enabled>true</enabled></snapshots>
+ </pluginRepository></pluginRepositories>
 </profile></profiles>
     <servers>
 <server>

--- a/settings.test.js
+++ b/settings.test.js
@@ -87,7 +87,7 @@ afterAll(() => {
     }
 
     try {
-        fs.rmdirSync(testHomePath);
+        fs.rmSync(testHomePath, { recursive: true });
     } catch (error) {
     }
 });
@@ -821,14 +821,57 @@ test('addCustomRepositories - one with snapshots one without', () => {
      <id>repoId</id>
      <name>repoName</name>
      <url>url</url>
+     
      <snapshots><enabled>true</enabled></snapshots>
  </repository> <repository>
      <id>repoId2</id>
      
      <url>url2</url>
      
+     
  </repository></repositories>
     <pluginRepositories/>
+</profile></profiles>`);
+});
+
+test('addCustomPluginRepositories - one with releases and snapshots one without', () => {
+
+    process.env['INPUT_PLUGINREPOSITORIES'] = `
+      [{"id":"repoId",
+        "name":"repoName",
+        "url":"url",
+        "releases":{"enabled":false},
+        "snapshots":{"enabled":true}
+       },{
+        "id":"repoId2",
+        "url":"url2"
+      }]`
+
+    const xml = stringAsXml('<profiles/>');
+
+    settings.fillRepositories(xml,'pluginRepositories');
+
+    const xmlStr = new XMLSerializer().serializeToString(xml);
+    expect(xmlStr).toBe(`<profiles>
+<profile>
+    <id>_custom_repositories_</id>
+    <activation>
+        <activeByDefault>true</activeByDefault>
+    </activation>
+    <repositories/>
+    <pluginRepositories> <pluginRepository>
+     <id>repoId</id>
+     <name>repoName</name>
+     <url>url</url>
+     <releases><enabled>false</enabled></releases>
+     <snapshots><enabled>true</enabled></snapshots>
+ </pluginRepository> <pluginRepository>
+     <id>repoId2</id>
+     
+     <url>url2</url>
+     
+     
+ </pluginRepository></pluginRepositories>
 </profile></profiles>`);
 });
 

--- a/templates/pluginRepositories.xml
+++ b/templates/pluginRepositories.xml
@@ -1,7 +1,7 @@
- <repository>
+ <pluginRepository>
      <id/>
      <name/>
      <url/>
      <releases/>
      <snapshots/>
- </repository>
+ </pluginRepository>


### PR DESCRIPTION
Add support for pluginRepositories as per issue #348

A configuration like the following:
```yml
steps:
- uses: s4u/maven-settings-action@master
  with:
    pluginRepositories: >-
      [{
        "id": "repoId",
        "name": "repoName",
        "url": "url",
        "releases": {
          "enabled": false
        },
        "snapshots": {
          "enabled": true
        }
      }]
```

Will result in a settings.xml like the following:
```xml
<profiles>
  <profile>
    <id>_custom_repositories_</id>
    <activation>
        <activeByDefault>true</activeByDefault>
    </activation>
    <repositories/>
    <pluginRepositories> 
      <pluginRepository>
        <id>repoId</id>
        <name>repoName</name>
        <url>url</url>
        <releases><enabled>false</enabled></releases>
        <snapshots><enabled>true</enabled></snapshots>
      </pluginRepository>
    </pluginRepositories>
  </profile>
</profiles>
```